### PR TITLE
Fix return type of `withKnexTrx`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,10 @@ export const knexTrxErrorHandler: ErrorRequestHandler = async (err, req, res, ne
   next(err);
 };
 
-export const withKnexTrx = (knex: Knex, middlewares: RequestHandlerParams): RequestHandlerParams => {
+export const withKnexTrx = (
+  knex: Knex,
+  middlewares: RequestHandlerParams,
+): (RequestHandler | ErrorRequestHandler)[] => {
   checkKnex(knex);
   checkMiddlewares(middlewares);
 


### PR DESCRIPTION
Since `withKnexTrx()` will always return an array of handlers, RequestHandlerParams doesn't work well here because it can be a scalar value.

Solution: Use (RequestHandler | ErrorRequestHandler)[] instead.